### PR TITLE
Fade photo edges for seamless hero section

### DIFF
--- a/workspace/portfolio/src/components/Hero.tsx
+++ b/workspace/portfolio/src/components/Hero.tsx
@@ -12,12 +12,12 @@ export default function Hero() {
       {/* Right-aligned background photo with left fade */}
       <div
         aria-hidden
-        className="pointer-events-none absolute right-3 top-16 bottom-3 hidden w-[48%] rounded-xl md:block overflow-hidden shadow-2xl ring-1 ring-white/5"
+        className="pointer-events-none absolute right-3 top-16 bottom-3 hidden w-[48%] md:block overflow-hidden"
       >
         <img
           src={YC_IMG}
           alt="YC demo background"
-          className="h-full w-full object-cover object-center"
+          className="h-full w-full object-cover object-center mask-fade-edges"
         />
         <div className="absolute inset-0 bg-gradient-to-l from-transparent via-neutral-950/40 to-neutral-950" />
       </div>

--- a/workspace/portfolio/src/index.css
+++ b/workspace/portfolio/src/index.css
@@ -22,3 +22,14 @@
     @apply inline-flex items-center rounded-full border border-neutral-700/60 bg-neutral-900 px-2.5 py-1 text-xs text-neutral-200;
   }
 }
+
+@layer utilities {
+  .mask-fade-edges {
+    -webkit-mask-image: radial-gradient(120% 120% at 50% 50%, #000 58%, rgba(0,0,0,0.85) 72%, transparent 92%);
+    mask-image: radial-gradient(120% 120% at 50% 50%, #000 58%, rgba(0,0,0,0.85) 72%, transparent 92%);
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+  }
+}


### PR DESCRIPTION
Fades all edges of the hero YC photo and removes rounded corners to improve its seamless integration with the background.

---
<a href="https://cursor.com/background-agent?bcId=bc-83f93182-7a8c-486f-96b5-c21ad82f88f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83f93182-7a8c-486f-96b5-c21ad82f88f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

